### PR TITLE
Handle recorded events and save the video file to external storage

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
 
     <uses-permission android:name="android.permission.VIDEO_CAPTURE" />
     <uses-permission android:name="android.permission.AUDIO_CAPTURE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/jammhealth/demo/OpenRoomActivity.java
+++ b/app/src/main/java/com/jammhealth/demo/OpenRoomActivity.java
@@ -2,15 +2,19 @@ package com.jammhealth.demo;
 
 import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 
 import android.Manifest;
 import android.annotation.TargetApi;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.content.res.AssetFileDescriptor;
 import android.content.res.Configuration;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Environment;
+import android.util.Base64;
 import android.util.Log;
 import android.webkit.JavascriptInterface;
 import android.webkit.PermissionRequest;
@@ -20,6 +24,10 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
 import org.json.JSONObject;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
 
 class JSBridge {
     AppCompatActivity activity = null;
@@ -36,6 +44,27 @@ class JSBridge {
             if (data.getString("type").equals("end") || data.getString("type").equals("disconnected")) {
                 // Finish the activity if they click the end button or disconnect
                 this.activity.finish();
+            }
+            if (data.getString("type").equals("recorded")) {
+                Log.d("OpenRoom", "Saving recorded video to external storage");
+                ActivityCompat.requestPermissions(this.activity, new String[] { Manifest.permission.WRITE_EXTERNAL_STORAGE }, 1);
+                byte[] videoBlob = Base64.decode(data.getString("videoBlob"), Base64.DEFAULT);
+                File filepath = Environment.getExternalStorageDirectory();
+                File dir = new File(filepath.getAbsolutePath() + "/cliniscape/");
+                if (!dir.exists()) {
+                    dir.mkdirs();
+                }
+
+                File newFile = new File(dir, "save_"+System.currentTimeMillis()+".webm");
+
+                if (newFile.exists()) newFile.delete();
+
+                OutputStream out = new FileOutputStream(newFile);
+
+                // Copy the bits
+                out.write(videoBlob, 0, videoBlob.length);
+                out.close();
+                Log.v("OpenRoom", "Copy file successful.");
             }
         } catch(Exception e) {
             Log.e("OpenRoom", "Failed to parse JSON message " + dataJson);
@@ -120,7 +149,7 @@ public class OpenRoomActivity extends AppCompatActivity {
             public void onPageFinished(WebView view, String url) {
                 // Page has finished loading, inject the javascript to forward messages to our bridge
                 if (!loaded) {
-                    view.evaluateJavascript("(function() { window.addEventListener('message', function(event) { JSBridge.postMessage(JSON.stringify(event.data)) });})();", null);
+                    view.evaluateJavascript("(function() { window.addEventListener('message', function(event) { if (event.data.type === 'recorded') { var reader = new window.FileReader();reader.readAsDataURL(event.data.videoBlob);reader.onloadend = () => { const base64data = reader.result;JSBridge.postMessage(JSON.stringify({ type: event.data.type, videoBlob: base64data }));}} else { JSBridge.postMessage(JSON.stringify(event.data)); }});})();", null);
                     loaded = true;
                 }
             }


### PR DESCRIPTION
Taking the blob passed to window.postMessage and base64 encoding it and passing it to the JS Bridge

For now this is working with [a simple demo](https://output.jsbin.com/xamisag)

To test it out:

1. Launch the app
2. Enter https://output.jsbin.com/xamisag as the room URL and click OPEN
2. Click on the record button
3. Wait a few seconds and click the stop button
4. You should get prompted to allow access to write to storage if you haven't already allowed it. 
5. Allow access. You should see a player appear with the video. 
6. You can also find the video in the cliniscape folder of your external storage

![video-record-android-demo](https://user-images.githubusercontent.com/733672/95414586-ef92cc00-0979-11eb-8859-9a78ffc841df.gif)